### PR TITLE
Allow configuring namespace prefix generation

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -7,6 +7,7 @@
       "ignore": ["comments"]
       }
     ],
-    "scss/operator-no-newline-after": null
+    "scss/operator-no-newline-after": null,
+    "selector-class-pattern": null
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ compile-minimized: src/tidgrid.scss
 
 .PHONY: lint-scss
 lint-scss:
-	npx stylelint "src/**/*.scss"
+	npx stylelint "{src,test}/**/*.scss"
 
 .PHONY: fix-scss
 fix-scss:
-	npx stylelint "src/**/*.scss" --fix
+	npx stylelint "{src,test}/**/*.scss" --fix
 
 .PHONY: clean
 clean:

--- a/src/grid/row.scss
+++ b/src/grid/row.scss
@@ -6,6 +6,7 @@
 @use "util/string";
 @use "mode";
 @use "variant";
+@use "static";
 
 $row-sizes: (12, 16) !default;
 $fractions: (
@@ -21,32 +22,32 @@ $fractions: (
   }
 }
 
-.tg-row {
+@include static.declare(row) {
   display: flex;
   flex-flow: row wrap;
   box-sizing: border-box;
 }
 
 @include variant.generate {
-  @include variant.varying(tg-auto) {
+  @include variant.declare(auto) {
     @include child-cell {
       @include mode.auto;
     }
   }
 
-  @include variant.varying(tg-stacked) {
+  @include variant.declare(stacked) {
     @include child-cell {
       @include mode.stacked;
     }
   }
 
-  @include variant.varying(tg-thin) {
+  @include variant.declare(thin) {
     @include child-cell {
       @include mode.thin;
     }
   }
 
-  @include variant.varying(tg-fill) {
+  @include variant.declare(fill) {
     @include child-cell {
       @include mode.fill;
     }
@@ -56,7 +57,7 @@ $fractions: (
     $cell-width: math.percentage($value);
     $escaped-name: string.replace-first($name, "/", "\\/");
 
-    @include variant.varying(tg-frac-#{$escaped-name}) {
+    @include variant.declare(frac-#{$escaped-name}) {
       @include child-cell {
         width: $cell-width;
       }
@@ -68,7 +69,7 @@ $fractions: (
       @for $column from 1 through $row-size {
         $cell-width: #{math.div(100%, $row-size) * $column};
 
-        @include variant.varying(tg-span-#{$column}) {
+        @include variant.declare(span-#{$column}) {
           @include child-cell {
             width: $cell-width;
           }

--- a/src/namespace.scss
+++ b/src/namespace.scss
@@ -1,0 +1,10 @@
+/*
+ * namespace.scss
+ */
+
+$use-namespace: true !default;
+
+@function use-prefix($name) {
+  @return if($use-namespace, "tg-#{$name}", $name);
+}
+

--- a/src/namespace.scss
+++ b/src/namespace.scss
@@ -7,4 +7,3 @@ $use-namespace: true !default;
 @function use-prefix($name) {
   @return if($use-namespace, "tg-#{$name}", $name);
 }
-

--- a/src/static.scss
+++ b/src/static.scss
@@ -1,0 +1,11 @@
+/*
+ * static.scss
+ */
+
+@use "namespace";
+
+@mixin declare($name) {
+  .#{namespace.use-prefix($name)} {
+    @content;
+  }
+}

--- a/src/variant.scss
+++ b/src/variant.scss
@@ -4,6 +4,7 @@
 
 @use "sass:selector";
 @use "util/string";
+@use "namespace";
 
 $default-breakpoints: (
   xs: 36em, /* = 576 px */
@@ -25,7 +26,8 @@ $default-breakpoints: (
   }
 }
 
-@mixin varying($name) {
+@mixin declare($name) {
+  $name: namespace.use-prefix($name);
   $classname: $name;
 
   @if $breakpoint {

--- a/test/string.test.scss
+++ b/test/string.test.scss
@@ -27,7 +27,6 @@
       string.replace-first("hello world", "world", "tidgrid"),
       "hello tidgrid"
     );
-
     @include assert-equal(
       string.replace-first("1/2", "/", "\\/"),
       "1\\/2"

--- a/test/variant.test.scss
+++ b/test/variant.test.scss
@@ -33,6 +33,7 @@ $breakpoints: (
           width: unset;
         }
 
+        /* stylelint-disable selector-class-pattern */
         @media only screen and (min-width: 36em) {
           .xs\:tg-stacked > .tg-cell {
             flex: 1 0 0;
@@ -53,6 +54,7 @@ $breakpoints: (
             width: unset;
           }
         }
+        /* stylelint-enable selector-class-pattern */
       }
     }
   }

--- a/test/variant.test.scss
+++ b/test/variant.test.scss
@@ -18,7 +18,7 @@ $breakpoints: (
     @include assert {
       @include output($selector: false) {
         @include variant.generate($breakpoints) {
-          @include variant.varying(tg-stacked) {
+          @include variant.declare(stacked) {
             @include row.child-cell {
               flex: 1 0 0;
               width: unset;
@@ -61,7 +61,7 @@ $breakpoints: (
     @include assert {
       @include output($selector: false) {
         @include variant.generate(()) {
-          @include variant.varying(tg-stacked) {
+          @include variant.declare(stacked) {
             @include row.child-cell {
               flex: 1 0 0;
               width: unset;

--- a/test/variant.test.scss
+++ b/test/variant.test.scss
@@ -33,7 +33,6 @@ $breakpoints: (
           width: unset;
         }
 
-        /* stylelint-disable selector-class-pattern */
         @media only screen and (min-width: 36em) {
           .xs\:tg-stacked > .tg-cell {
             flex: 1 0 0;
@@ -54,7 +53,6 @@ $breakpoints: (
             width: unset;
           }
         }
-        /* stylelint-enable selector-class-pattern */
       }
     }
   }


### PR DESCRIPTION
All classes have `tg-` prefix by default, but now it can be disabled.